### PR TITLE
Fix android SVG export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-drawingpad",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "drawingpad",
   "typings": "index.d.ts",
   "description": "A NativeScript plugin to provide a way to capture any drawing (signatures are a common use case) from the device screen.",

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -8,5 +8,5 @@ android {
 }
 
 dependencies {
-     compile "com.github.gcacace:signature-pad:1.0.3"
+     compile "com.github.gcacace:signature-pad:1.2.1"
 }


### PR DESCRIPTION
Updates android deps to a newer version that supports export to SVG.