### PR TITLE
fix: unicode character in build.gradle file breaking build

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -1,4 +1,4 @@
-﻿//default elements
+//default elements
 android {
     productFlavors {
         "nativescriptsignaturepad" {


### PR DESCRIPTION
Fixes the error "Invalid variable name.Must start with a letter but was:" during build