### PR TITLE
can now turn off the long press gesture to clear

### DIFF
--- a/src/drawingpad-common.ts
+++ b/src/drawingpad-common.ts
@@ -6,6 +6,7 @@ export abstract class DrawingPadBase extends View
   implements DrawingPadDefinition {
   public penColor: Color;
   public penWidth: number;
+  public clearOnLongPress: boolean;
 
   public abstract clearDrawing(): void;
   public abstract getDrawing(): Promise<any>;
@@ -30,3 +31,9 @@ export const penWidthProperty = new Property<DrawingPadBase, number>({
   valueConverter: v => +v
 });
 penWidthProperty.register(DrawingPadBase);
+
+export const clearOnLongPressProperty = new Property<DrawingPadBase, boolean>({
+  name: 'clearOnLongPress',
+  defaultValue: true
+});
+clearOnLongPressProperty.register(DrawingPadBase);

--- a/src/drawingpad.ios.ts
+++ b/src/drawingpad.ios.ts
@@ -6,11 +6,13 @@ import { PercentLength } from 'tns-core-modules/ui/styling/style-properties';
 import {
   DrawingPadBase,
   penColorProperty,
-  penWidthProperty
+  penWidthProperty,
+  clearOnLongPressProperty
 } from './drawingpad-common';
 
 export class DrawingPad extends DrawingPadBase {
   public nativeView: SignatureView;
+  private _clearOnLongPress: boolean = true;
   constructor() {
     super();
     this.nativeView = SignatureView.alloc().initWithFrame(
@@ -36,6 +38,20 @@ export class DrawingPad extends DrawingPadBase {
   [penColorProperty.setNative](value: Color | UIColor) {
     const color = value instanceof Color ? value.ios : value;
     this.nativeView.setLineColor(color);
+  }
+
+  [clearOnLongPressProperty.getDefault](): boolean {
+    return this._clearOnLongPress;
+  }
+
+  [clearOnLongPressProperty.setNative](value: boolean) {
+    this._clearOnLongPress = value;
+    const rec = this.nativeView.recognizer;
+    if (!this._clearOnLongPress) {
+      rec && this.nativeView.removeGestureRecognizer(rec);
+    } else {
+      rec && this.nativeView.addGestureRecognizer(rec);
+    }
   }
 
   public onLoaded() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,11 @@ export class DrawingPad extends View {
 
   penWidth: number;
   /**
+   * Gets/sets whether a long press will clear the view.
+   */
+
+  clearOnLongPress: boolean;
+  /**
    * Returns native image.
    */
   getDrawing(): Promise<any>;


### PR DESCRIPTION
The CocoaPod that is used uses a long press gesture to clear the view. However, on doing so, the background color isn't persisted. This change will allow people to select whether they want to use that long press gesture or not. The gesture will still be on by default, and will only be removed when you set the `clearOnLongPress` property to `false`. It has been tested with two way binding in Angular, and setting it to `true` after it has been `false` will successfully add the gesture recognizer again.